### PR TITLE
Added support for H110i coolers

### DIFF
--- a/Link.cpp
+++ b/Link.cpp
@@ -46,19 +46,19 @@ int CorsairLink::Initialize()
 
 		// Open the device using the VID, PID,
 		// and optionally the Serial number.
-		// open Corsair H80i or H100i cooler 
+		// open Corsair H80i, H100i, or H110i cooler
 		handle = hid_open(0x1b1c, 0x0c04, NULL);
 		if (!handle)
 		{
-			fprintf(stderr, "Error: Unable to open Corsair H80i or H100i CPU Cooler\n");
+			fprintf(stderr, "Error: Unable to open Corsair H80i, H100i or H110i CPU Cooler\n");
 			return 0;
 		}
 		hid_set_nonblocking(handle, 1);
 
 		deviceId = this->GetDeviceId();
-		if ((deviceId != 0x3b) && (deviceId != 0x3c))
+		if ((deviceId != 0x3b) && (deviceId != 0x3c) && (deviceId != 0x41))
 		{
-			fprintf(stderr, "Device ID: %2x mismatch. Not Corsair H80i or H100i CPU Cooler\n", deviceId );
+			fprintf(stderr, "Device ID: %2x mismatch. Not Corsair H80i, H100i or H110i CPU Cooler\n", deviceId );
 			this->Close();
 			return 0;
 		}
@@ -73,7 +73,7 @@ int CorsairLink::GetDeviceId(void)
 {
 	memset(buf,0,sizeof(buf));
 
-	// Read Device ID: 0x3b = H80i. 0x3c = H100i
+	// Read Device ID: 0x3b = H80i. 0x3c = H100i. 0x41 = H110i
 	buf[0] = 0x03; // Length
 	buf[1] = this->CommandId++; // Command ID
 	buf[2] = ReadOneByte; // Command Opcode
@@ -97,7 +97,7 @@ int CorsairLink::GetFirmwareVersion()
 {
 	memset(buf,0,sizeof(buf));
 
-	// Read Device ID: 0x3b = H80i. 0x3c = H100i
+	// Read Device ID: 0x3b = H80i. 0x3c = H100i. 0x41 = H110i
 	buf[0] = 0x03; // Length
 	buf[1] = this->CommandId++; // Command ID
 	buf[2] = ReadTwoBytes; // Command Opcode
@@ -122,7 +122,7 @@ int CorsairLink::GetProductName(char *ostring)
 {
 	memset(buf,0,sizeof(buf));
 
-	// Read Device ID: 0x3b = H80i. 0x3c = H100i
+	// Read Device ID: 0x3b = H80i. 0x3c = H100i. 0x41 = H110i
 	buf[0] = 0x04; // Length
 	buf[1] = this->CommandId++; // Command ID
 	buf[2] = ReadThreeBytes; // Command Opcode


### PR DESCRIPTION
Just adjusted the device id check (and a few comments/messages) to include the newer H110i coolers. Fans, leds, and everything else seems to work fine without any other changes necessary.
